### PR TITLE
Clear countdown every time lobby is updated.

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -8117,6 +8117,7 @@
 	//LOCAL
 
 	var updateLobby = function(data) {
+		clearCountdown();
 		if (data.started) {
 			Timeout.setGameLobby(false);
 			Start.play(data);
@@ -8124,8 +8125,6 @@
 		}
 
 		showLobbySection('wait');
-
-		clearCountdown();
 
 		State.players = data.players;
 		var lobbyPlayerCount = data.players.length;
@@ -28454,13 +28453,13 @@
 		if (action == 'abandoned') {
 			Players.abandoned(data);
 		} else if (action == 'chat') {
-			Audio.chatAlert();
-			Chat.addMessage(data);
+	//		Audio.chatAlert();
+			Chat.addMessage(data); 
 		} else if (action == 'chancellor chosen') {
 			Audio.chancellorChosenAlert();
 			Players.chancellorChosen(data);
 		} else if (action == 'voted') {
-			Audio.votedAlert();
+	//		Audio.votedAlert();
 			Game.voteCompleted(data);
 		} else if (action == 'discarded') {
 			Policies.discarded(data);

--- a/public/scripts/lobby/lobby.js
+++ b/public/scripts/lobby/lobby.js
@@ -50,6 +50,7 @@ var updateCountdown = function() {
 //LOCAL
 
 var updateLobby = function(data) {
+	clearCountdown();
 	if (data.started) {
 		Timeout.setGameLobby(false);
 		Start.play(data);
@@ -57,8 +58,6 @@ var updateLobby = function(data) {
 	}
 
 	showLobbySection('wait');
-
-	clearCountdown();
 
 	State.players = data.players;
 	var lobbyPlayerCount = data.players.length;


### PR DESCRIPTION
There was a bug where if a lobby fills up completely. The dings will be heard one minute after game starting. 

When the game is started forcefully by a full room of 10 players, we end up hearing dings 1 minute after game has started. This fixes that issue.

But there is still 1 pending issue, if a game is started by a full lobby, you won't hear dings at all because the countdown timer didn't get a chance to do a 3,2,1. We need a simple ding notification for that when game starts.

